### PR TITLE
Add method that sets and flattens a viper key

### DIFF
--- a/kubectl-volsync/cmd/migration.go
+++ b/kubectl-volsync/cmd/migration.go
@@ -58,26 +58,14 @@ type migrationRelationshipDestination struct {
 }
 
 func (mr *migrationRelationship) Save() error {
-	mr.Set("data", mr.data)
-	// resource.Quantity doesn't properly encode, so we need to do it manually.
-	// TODO: Find a solution for below behavior to avoid multiple mr.Set() statements.
-	// If we set capacity explicitly, it will override mr.set("data", mr.data)
-	// behavior and only capacity will be set. So resetting every other fields
-	// explicitly.
-	if mr.data.Destination != nil && mr.data.Destination.Destination.Capacity != nil {
-		mr.Set("data.destination.spec.Capacity", mr.data.Destination.Destination.Capacity.String())
-		mr.Set("data.destination.Cluster", mr.data.Destination.Cluster)
-		mr.Set("data.destination.Namespace", mr.data.Destination.Namespace)
-		mr.Set("data.destination.PVCName", mr.data.Destination.PVCName)
-		mr.Set("data.destination.MDName", mr.data.Destination.MDName)
-		mr.Set("data.destination.spec.ServiceType", mr.data.Destination.Destination.ServiceType)
-		mr.Set("data.destination.spec.AccessModes", mr.data.Destination.Destination.AccessModes)
-		mr.Set("data.destination.spec.CopyMethod", mr.data.Destination.Destination.CopyMethod)
+	if err := mr.SetData(mr.data); err != nil {
+		return err
+	}
 
-		mr.Set("data.destination.spec.StorageClassName", mr.data.Destination.Destination.StorageClassName)
-		mr.Set("data.destination.rsync.Address", mr.data.Destination.Destination.Address)
-		mr.Set("data.destination.rsync.Port", mr.data.Destination.Destination.Port)
-		mr.Set("data.destination.rsync.SSHKeys", mr.data.Destination.Destination.SSHKeys)
+	// resource.Quantity doesn't properly encode, so we need to do it manually.
+	if mr.data.Destination != nil && mr.data.Destination.Destination.Capacity != nil {
+		mr.Set("data.destination.destination.replicationdestinationvolumeoptions.capacity",
+			mr.data.Destination.Destination.Capacity.String())
 	}
 
 	return mr.Relationship.Save()

--- a/kubectl-volsync/cmd/relationship.go
+++ b/kubectl-volsync/cmd/relationship.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
 	"k8s.io/klog/v2"
 )
 
@@ -141,4 +142,19 @@ func (r *Relationship) Type() RelationshipType {
 // ID returns the UUID of this relationship.
 func (r *Relationship) ID() uuid.UUID {
 	return uuid.MustParse(r.GetString("id"))
+}
+
+// Sets the "data" subkey with the contents of a struct and flattens it so that
+// individual values may be overridden
+func (r *Relationship) SetData(data interface{}) error {
+	bytes, err := yaml.Marshal(data)
+	if err != nil {
+		return err
+	}
+	ms := map[string]interface{}{}
+	if err = yaml.Unmarshal(bytes, &ms); err != nil {
+		return err
+	}
+	r.Set("data", ms)
+	return nil
 }


### PR DESCRIPTION
This allows setting the Viper "data" key that we use for relationship
data. It also "flattens" the structure stored there so that sub-paths
within that key can be directly overwritten without destroying the other
data stored there. This is necessary when structures don't properly
serialize on their own.